### PR TITLE
Wip develop watchdog stop write v 2 4 0

### DIFF
--- a/arch/arm/mach-omap2/board-mc341.c
+++ b/arch/arm/mach-omap2/board-mc341.c
@@ -110,6 +110,7 @@
 //                                      * I2C0 and I2C1 disable pull down.
 //                                      * Change gpmc_wen pin mode gpio2_4 and input pulldown for mc341 series.(not other series.) 
 //                             (12) Change musb_babble_workaround in ti81xx_interrupt.
+// update 2020.07.02 Ver.2.4.1 (1) omap watchdog timer support echo "V" command.
 //#define MC341LAN2 (1)
 #define MC341
 #ifndef MC341
@@ -118,7 +119,7 @@
 #endif
 
 // update 2020.03.12
-#define CPS_KERNEL_VERSION "Ver.2.4.0 (build: 2020.03.13) "
+#define CPS_KERNEL_VERSION "Ver.2.4.1 (build: 2020.07.02) "
 
 #include <linux/kernel.h>
 #include <linux/init.h>

--- a/arch/arm/mach-omap2/board-mc341.c
+++ b/arch/arm/mach-omap2/board-mc341.c
@@ -110,7 +110,10 @@
 //                                      * I2C0 and I2C1 disable pull down.
 //                                      * Change gpmc_wen pin mode gpio2_4 and input pulldown for mc341 series.(not other series.) 
 //                             (12) Change musb_babble_workaround in ti81xx_interrupt.
-// update 2020.07.02 Ver.2.4.1 (1) omap watchdog timer support echo "V" command.
+// update 2020.10.30 Ver.2.4.1 (1) Update omap watchdog timer .
+//                                      * support echo "V" command (disable watchdog).
+//                                      * support echo "300" (set timeout).
+//                                      * bugfix set default timeout 300sec, but watchdog reset before 300sec (probe only).
 //#define MC341LAN2 (1)
 #define MC341
 #ifndef MC341
@@ -119,7 +122,7 @@
 #endif
 
 // update 2020.03.12
-#define CPS_KERNEL_VERSION "Ver.2.4.1 (build: 2020.07.02) "
+#define CPS_KERNEL_VERSION "Ver.2.4.1 (build: 2020.10.30) "
 
 #include <linux/kernel.h>
 #include <linux/init.h>

--- a/drivers/watchdog/omap_wdt.c
+++ b/drivers/watchdog/omap_wdt.c
@@ -66,7 +66,7 @@ struct omap_wdt_dev {
 	unsigned int			irq;		//update 2017.07.22
 	struct resource *mem;
 	struct miscdevice omap_wdt_miscdev;
-
+	unsigned int enable; //update 2020.07.02
 	void (*restart)(char mode, const char *cmd);//update 2017.07.22
 };
 
@@ -99,6 +99,8 @@ static void omap_wdt_enable(struct omap_wdt_dev *wdev)
 	__raw_writel(0x4444, base + OMAP_WATCHDOG_SPR);
 	while ((__raw_readl(base + OMAP_WATCHDOG_WPS)) & 0x10)
 		cpu_relax();
+
+	wdev->enable = 1;
 }
 
 static void omap_wdt_disable(struct omap_wdt_dev *wdev)
@@ -113,6 +115,8 @@ static void omap_wdt_disable(struct omap_wdt_dev *wdev)
 	__raw_writel(0x5555, base + OMAP_WATCHDOG_SPR);	/* TIMER_MODE */
 	while (__raw_readl(base + OMAP_WATCHDOG_WPS) & 0x10)
 		cpu_relax();
+
+	wdev->enable = 0;
 }
 
 static void omap_wdt_adjust_timeout(unsigned new_timeout)
@@ -292,14 +296,29 @@ static ssize_t omap_wdt_write(struct file *file, const char __user *data,
 		size_t len, loff_t *ppos)
 {
 	struct omap_wdt_dev *wdev = file->private_data;
+	char stop_watchdog_code = 'V';
 
-	/* Refresh LOAD_TIME. */
+	
 	if (len) {
-		pm_runtime_get_sync(wdev->dev);
-		spin_lock(&wdt_lock);
-		omap_wdt_ping(wdev);
-		spin_unlock(&wdt_lock);
-		pm_runtime_put_sync(wdev->dev);
+		if( len == 1 &&
+			!memcmp(&buf[0], &stop_watchdog_code, 1) &&
+			wdev->enable == 1 
+		){
+			pm_runtime_get_sync(wdev->dev);
+			omap_wdt_disable(wdev);
+			pm_runtime_put_sync(wdev->dev);
+		}
+		else{
+			/* Refresh LOAD_TIME. */
+			pm_runtime_get_sync(wdev->dev);
+			if( wdev->enable == 0 )
+				omap_wdt_enable(wdev);
+						
+			spin_lock(&wdt_lock);
+			omap_wdt_ping(wdev);
+			spin_unlock(&wdt_lock);
+			pm_runtime_put_sync(wdev->dev);
+		}
 	}
 	return len;
 }

--- a/drivers/watchdog/omap_wdt.c
+++ b/drivers/watchdog/omap_wdt.c
@@ -301,7 +301,7 @@ static ssize_t omap_wdt_write(struct file *file, const char __user *data,
 	
 	if (len) {
 		if( len == 1 &&
-			!memcmp(&buf[0], &stop_watchdog_code, 1) &&
+			!memcmp(&data[0], &stop_watchdog_code, 1) &&
 			wdev->enable == 1 
 		){
 			pm_runtime_get_sync(wdev->dev);

--- a/drivers/watchdog/omap_wdt.c
+++ b/drivers/watchdog/omap_wdt.c
@@ -317,7 +317,7 @@ static ssize_t omap_wdt_write(struct file *file, const char __user *data,
 			/* Set new timeout data */
 			if( data[0] >='0' && data[0] <='9' ){
 				for( count = 0; count < len; count ++ ){
-					if ( data[count] >='0' && data[0] <='9' ){
+					if ( data[count] >='0' && data[count] <='9' ){
 						new_timeout = new_timeout * 10 + (data[count] - '0' );
 					}
 				}


### PR DESCRIPTION
* bugfix watchodog timer sets 5 min, but it resets about 4 min.
* support /dev/watchdog echo "V" command.
* support /dev/watchdog echo "300" values set watchdog timer again.